### PR TITLE
explicit utf-8 usage

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -3,6 +3,7 @@
 module.exports = props => `<!DOCTYPE html>
 <html lang="en-US">
   <head>
+    <meta charset="utf-8">
     <title>${props.title}</title>
 ${props.fonts || ''}
     <style type="text/css">


### PR DESCRIPTION
I found current template is not specifying character encoding.
It is better to specify UTF-8 for best compatibility.